### PR TITLE
add GitHub Actions workflow for dev deploys

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,28 @@
+name: Build and trigger deploy to dev server
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-artifact
+        path: build
+        retention-days: 5


### PR DESCRIPTION
After merging this, you will be able to trigger the dev deploy action from the `Actions` tab of this repo's GitHub page.

The should deploy to dev.ldn-gis.co.uk/data-for-london