### PR TITLE
handle error when content is not found

### DIFF
--- a/src/lib/MarkdownToHtml.ts
+++ b/src/lib/MarkdownToHtml.ts
@@ -3,7 +3,12 @@ import fs from 'fs';
 import path from 'path';
 
 export async function getMarkdownContent(fileName: string): Promise<string> {
-	const filePath = path.join(process.cwd(), 'src/content', fileName);
-	const content = fs.readFileSync(filePath, 'utf8');
-	return content;
+  try {
+    const filePath = path.join(process.cwd(), 'src/content', fileName);
+    const content = fs.readFileSync(filePath, 'utf8');
+    return content;
+  } catch (error) {
+    console.error(`Error reading Markdown file ${fileName}:`, error);
+    return '# No Content Available\n\nThe requested content could not be found.'; // Provide a fallback content
+  }
 }


### PR DESCRIPTION
Added error handling for the case when markdown file is not found. This prevents the site from crashing in case of a typo or a missing file.